### PR TITLE
Allow all options provided by the file module.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,14 @@
 
 - name: Create custom directories
   file:
-    path: '{{ item.path }}'
-    state: '{{ item.state | default("directory") }}'
-    owner: '{{ item.owner | default("root") }}'
-    group: '{{ item.group | default("root") }}'
-    mode: '{{ item.mode | default("0755") }}'
+    path:   '{{ item.path }}'
+    state:  '{{ item.state  | default("directory") }}'
+    owner:  '{{ item.owner  | default("root") }}'
+    group:  '{{ item.group  | default("root") }}'
+    mode:   '{{ item.mode   | default("0755") }}'
+    follow: '{{ item.follow | default(omit) }}'
+    force:  '{{ item.force  | default(omit) }}'
+    src:    '{{ item.src    | default(omit) }}'
   with_flattened:
     - directories_list
     - directories_group_list


### PR DESCRIPTION
I have been using [franklinkim.files](https://github.com/weareinteractive/ansible-files) and then saw that there is a role for this in DebOps. I just wanted to create a link and it did not work …